### PR TITLE
Fix datatype for methyGff -hs argument

### DIFF
--- a/scripts/BatMeth2.cpp
+++ b/scripts/BatMeth2.cpp
@@ -35,7 +35,7 @@ int coverage = 4;
 int maxcoverage = 1000;
 int binCover = 1;
 int chromstep = 50000;
-float hs=0.4
+float hs = 0.4;
 //methyGff
 float step = 0.01;
 int distance = 2000;
@@ -968,11 +968,11 @@ void annotation(string outputdir, string output_prefix){
     string cmd;
     if(gfffile != "None")
         if(GTF)
-            cmd = abspath + "methyGff" + " -o " + outputdir + output_prefix + " -G " + genome_index + " -gtf " + gfffile + " -m " + methratio + " -B -P --TSS --TTS --GENE -hs " + hs;
+            cmd = abspath + "methyGff" + " -o " + outputdir + output_prefix + " -G " + genome_index + " -gtf " + gfffile + " -m " + methratio + " -B -P --TSS --TTS --GENE -hs " + getstring(hs);
         else
-            cmd = abspath + "methyGff" + " -o " + outputdir + output_prefix + " -G " + genome_index + " -gff " + gfffile + " -m " + methratio + " -B -P --TSS --TTS --GENE -hs " + hs;
+            cmd = abspath + "methyGff" + " -o " + outputdir + output_prefix + " -G " + genome_index + " -gff " + gfffile + " -m " + methratio + " -B -P --TSS --TTS --GENE -hs " + getstring(hs);
     else if(bedfile != "None")
-        cmd = abspath + "methyGff" + " -o " + outputdir + output_prefix + " -G " + genome_index + " -b " + bedfile + " -m " + methratio + " -B -P --TSS --TTS --GENE -hs "+hs;
+        cmd = abspath + "methyGff" + " -o " + outputdir + output_prefix + " -G " + genome_index + " -b " + bedfile + " -m " + methratio + " -B -P --TSS --TTS --GENE -hs " + getstring(hs);
     else {
     	fprintf(stderr, "\nWarning: not defined gtf/gff/bed file, so skip annatation.\n");
     	return;


### PR DESCRIPTION
This is intended to fix #26 

This pull request will change the methyGff command ("cmd") string building so that it converts the "hs" parameter to a string before appending.